### PR TITLE
Alter url in places_service.dart to strictly restrict search to Great…

### DIFF
--- a/bicycle_trip_planner/lib/services/places_service.dart
+++ b/bicycle_trip_planner/lib/services/places_service.dart
@@ -8,7 +8,7 @@ class PlacesService {
   Future<List<PlaceSearch>> getAutocomplete(String search) async {
     const key = 'AIzaSyBcUJrLd8uIYR2HFTNa6mj-7lVRyUIJXs0';
     var url =
-        'https://maps.googleapis.com/maps/api/place/autocomplete/json?input=$search&key=$key';
+        'https://maps.googleapis.com/maps/api/place/autocomplete/json?input=$search&components=country:gb&location=51.495830%2C-0.145607&radius=35000&strictbounds=true&key=$key';
     var response = await http.get(Uri.parse(url));
     var json = convert.jsonDecode(response.body);
     var jsonResults = json['predictions'] as List;


### PR DESCRIPTION
Change url in places_services file to have autocomplete restrict search area to only be within Greater London, further improvements might be possible to be made to restrict it further however current implementation should be good enough, reviewers might want to fiddle around with radius parameter to see if they want to restrict the bounds any further

closes #186 