### PR TITLE
Add button to go from Home to RoutePlanning

### DIFF
--- a/bicycle_trip_planner/lib/widgets/home/HomeWidgets.dart
+++ b/bicycle_trip_planner/lib/widgets/home/HomeWidgets.dart
@@ -1,9 +1,12 @@
+import 'package:bicycle_trip_planner/bloc/application_bloc.dart';
 import 'package:bicycle_trip_planner/constants.dart';
 import 'package:bicycle_trip_planner/managers/RouteManager.dart';
+import 'package:bicycle_trip_planner/widgets/general/CircleButton.dart';
 import 'package:bicycle_trip_planner/widgets/general/CurrentLocationButton.dart';
 import 'package:flutter/material.dart';
 import 'package:bicycle_trip_planner/widgets/general/Search.dart';
 import 'package:bicycle_trip_planner/widgets/home/StationBar.dart';
+import 'package:provider/provider.dart';
 import '../general/GroupSizeSelector.dart';
 import '../settings/SettingsScreen.dart';
 
@@ -19,6 +22,8 @@ class _HomeWidgetsState extends State<HomeWidgets> {
 
   @override
   Widget build(BuildContext context) {
+    final applicationBloc = Provider.of<ApplicationBloc>(context);
+
     return SafeArea(
       bottom: false,
       child: Stack(
@@ -100,6 +105,11 @@ class _HomeWidgetsState extends State<HomeWidgets> {
                                   CurrentLocationButton(),
                                   SizedBox(height: 10),
                                   GroupSizeSelector(),
+                                  SizedBox(height: 10),
+                                  CircleButton(
+                                      iconIn: Icons.assistant_direction,
+                                      onButtonClicked: () => applicationBloc.setSelectedScreen('routePlanning'),
+                                  ),
                                 ],
                               )),
                         ],


### PR DESCRIPTION
This button allows user to go to the RoutePlanning page directly, instead of having to click on a station on the stationBar or directly setting a destination from the search bar. 